### PR TITLE
Rebar3x support profile

### DIFF
--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -125,8 +125,8 @@ APP_VSN=${START_ERL#* }
 ERTS_PATH=$RUNNER_BASE_DIR/erts-$ERTS_VSN/bin
 
 # Setup command to control the node
-NODETOOL="$ERTS_PATH/escript $ERTS_PATH/nodetool $NET_TICKTIME_ARG $NAME_ARG $COOKIE_ARG"
-NODETOOL_LITE="$ERTS_PATH/escript $ERTS_PATH/nodetool"
+NODETOOL="$ERTS_PATH/escript $RUNNER_SCRIPT_DIR/nodetool $NET_TICKTIME_ARG $NAME_ARG $COOKIE_ARG"
+NODETOOL_LITE="$ERTS_PATH/escript $RUNNER_SCRIPT_DIR/nodetool"
 
 
 ## Are we using cuttlefish (http://github.com/basho/cuttlefish)
@@ -136,7 +136,7 @@ CUTTLEFISH="{{cuttlefish}}"
 if [ -z "$CUTTLEFISH" ]; then
     CUTTLEFISH_COMMAND_PREFIX=""
 else
-    CUTTLEFISH_COMMAND_PREFIX="$ERTS_PATH/escript $ERTS_PATH/cuttlefish -e $RUNNER_ETC_DIR -s $CUTTLEFISH_SCHEMA_DIR -d {{platform_data_dir}}/generated.configs -c $RUNNER_ETC_DIR/{{cuttlefish_conf}}"
+    CUTTLEFISH_COMMAND_PREFIX="$ERTS_PATH/escript $RUNNER_SCRIPT_DIR/cuttlefish -e $RUNNER_ETC_DIR -s $CUTTLEFISH_SCHEMA_DIR -d {{platform_data_dir}}/generated.configs -c $RUNNER_ETC_DIR/{{cuttlefish_conf}}"
 fi
 
 # Ping node without stealing stdin

--- a/priv/templates/deb/deb.template
+++ b/priv/templates/deb/deb.template
@@ -16,6 +16,7 @@
              {license_type, "license_type"},
              {license_full_text, ""},
              {bin_or_sbin, "bin"},
+             {rebar_profile, "default"},
 
              %% Platform Specific Settings
              {platform_bin_dir,  "/usr/{{bin_or_sbin}}"},

--- a/priv/templates/deb/install
+++ b/priv/templates/deb/install
@@ -1,12 +1,12 @@
-_build/default/rel/{{package_install_name}}/lib usr/lib/{{package_install_name}}
-_build/default/rel/{{package_install_name}}/erts* usr/lib/{{package_install_name}}
-_build/default/rel/{{package_install_name}}/releases usr/lib/{{package_install_name}}
+_build/{{rebar_profile}}/rel/{{package_install_name}}/lib usr/lib/{{package_install_name}}
+_build/{{rebar_profile}}/rel/{{package_install_name}}/erts* usr/lib/{{package_install_name}}
+_build/{{rebar_profile}}/rel/{{package_install_name}}/releases usr/lib/{{package_install_name}}
 
 {{#package_commands}}
-_build/default/rel/{{package_install_name}}/bin/{{name}} usr/{{bin_or_sbin}}
+_build/{{rebar_profile}}/rel/{{package_install_name}}/bin/{{name}} usr/{{bin_or_sbin}}
 {{/package_commands}}
 
-_build/default/rel/{{package_install_name}}/etc/* etc/{{package_install_name}}
-_build/default/rel/{{package_install_name}}/data/* var/lib/{{package_install_name}}
-_build/default/rel/{{package_install_name}}/data/* var/lib/{{package_install_name}}
-_build/default/rel/{{package_install_name}}/share/* usr/share/{{package_install_name}}
+_build/{{rebar_profile}}/rel/{{package_install_name}}/etc/* etc/{{package_install_name}}
+_build/{{rebar_profile}}/rel/{{package_install_name}}/data/* var/lib/{{package_install_name}}
+_build/{{rebar_profile}}/rel/{{package_install_name}}/data/* var/lib/{{package_install_name}}
+_build/{{rebar_profile}}/rel/{{package_install_name}}/share/* usr/share/{{package_install_name}}

--- a/priv/templates/deb/rules
+++ b/priv/templates/deb/rules
@@ -35,8 +35,8 @@ install: build
 	dh_prep
 	dh_installdirs
 	## copy the start_clean.boot
-	if [ -f _build/default/rel/{{package_install_name}}/bin/start_clean.boot ]; then \
-		cp _build/default/rel/{{package_install_name}}/bin/start_clean.boot \
+	if [ -f _build/{{rebar_profile}}/rel/{{package_install_name}}/bin/start_clean.boot ]; then \
+		cp _build/{{rebar_profile}}/rel/{{package_install_name}}/bin/start_clean.boot \
 				debian/{{package_name}}/usr/lib/{{package_install_name}}; fi
 	dh_install
 	dh_installman

--- a/priv/templates/fbsd/Makefile
+++ b/priv/templates/fbsd/Makefile
@@ -133,15 +133,15 @@ $(BUILD_STAGE_DIR): buildrel
 	@echo "Copying rel directory to staging directory"
 	mkdir -p $@
 	mkdir -p $(PBIN_DIR)
-	cp -R _build/default/rel/{{package_install_name}}/bin/* $(PBIN_DIR)
+	cp -R _build/{{rebar_profile}}/rel/{{package_install_name}}/bin/* $(PBIN_DIR)
 	mkdir -p $(PETC_DIR)
-	cp -R _build/default/rel/{{package_install_name}}/etc/* $(PETC_DIR)
+	cp -R _build/{{rebar_profile}}/rel/{{package_install_name}}/etc/* $(PETC_DIR)
 	mkdir -p $(PLIB_DIR)
-	cp -R _build/default/rel/{{package_install_name}}/lib $(PLIB_DIR)
-	cp -R _build/default/rel/{{package_install_name}}/erts-* $(PLIB_DIR)
-	cp -R _build/default/rel/{{package_install_name}}/releases $(PLIB_DIR)
+	cp -R _build/{{rebar_profile}}/rel/{{package_install_name}}/lib $(PLIB_DIR)
+	cp -R _build/{{rebar_profile}}/rel/{{package_install_name}}/erts-* $(PLIB_DIR)
+	cp -R _build/{{rebar_profile}}/rel/{{package_install_name}}/releases $(PLIB_DIR)
 	mkdir -p $(PDATA_DIR)
-	cp -R _build/default/rel/{{package_install_name}}/data/* $(PDATA_DIR)
+	cp -R _build/{{rebar_profile}}/rel/{{package_install_name}}/data/* $(PDATA_DIR)
 	mkdir -p $(PLOG_DIR)
 
 
@@ -150,7 +150,7 @@ $(BUILD_STAGE_DIR): buildrel
 #  * copy the vars.config over for build config
 buildrel:
 	OVERLAY_VARS="overlay_vars=../fbsd/vars.config" $(MAKE) rel
-	chmod 0755 _build/default/rel/{{package_install_name}}/bin/* _build/default/rel/{{package_install_name}}/erts-*/bin/*
+	chmod 0755 _build/{{rebar_profile}}/rel/{{package_install_name}}/bin/* _build/{{rebar_profile}}/rel/{{package_install_name}}/erts-*/bin/*
 
 $(BUILDDIR):
 	mkdir -p $@

--- a/priv/templates/fbsd/fbsd.template
+++ b/priv/templates/fbsd/fbsd.template
@@ -9,6 +9,7 @@
              {package_install_group, "package_install_group"},
              {bin_or_sbin, "bin"},
              {freebsd_package_category, "db"},
+             {rebar_profile, "default"},
 
              %% Platform-specific installation paths
              {platform_bin_dir,  "/usr/local/{{bin_or_sbin}}"},

--- a/priv/templates/fbsdng/Makefile
+++ b/priv/templates/fbsdng/Makefile
@@ -21,7 +21,7 @@ PKGNAME = {{package_name}}-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tbz
 
 # Recursive assignment of ERTS version
 # We will know this after building the rel
-ERTS_PATH = $(shell ls $(BUILDDIR)/_build/default/rel/{{package_install_name}} | egrep -o "erts-.*")
+ERTS_PATH = $(shell ls $(BUILDDIR)/_build/{{rebar_profile}}/rel/{{package_install_name}} | egrep -o "erts-.*")
 
 build: packing_list_files
 	@echo "Building package $(PKGNAME)"
@@ -78,15 +78,15 @@ $(BUILD_STAGE_DIR): buildrel
 	@echo "Copying rel directory to staging directory"
 	mkdir -p $@
 	mkdir -p $(PBIN_DIR)
-	cp -R _build/default/rel/{{package_install_name}}/bin/* $(PBIN_DIR)
+	cp -R _build/{{rebar_profile}}/rel/{{package_install_name}}/bin/* $(PBIN_DIR)
 	mkdir -p $(PETC_DIR)
-	cp -R _build/default/rel/{{package_install_name}}/etc/* $(PETC_DIR)
+	cp -R _build/{{rebar_profile}}/rel/{{package_install_name}}/etc/* $(PETC_DIR)
 	mkdir -p $(PLIB_DIR)
-	cp -R _build/default/rel/{{package_install_name}}/lib $(PLIB_DIR)
-	cp -R _build/default/rel/{{package_install_name}}/erts-* $(PLIB_DIR)
-	cp -R _build/default/rel/{{package_install_name}}/releases $(PLIB_DIR)
+	cp -R _build/{{rebar_profile}}/rel/{{package_install_name}}/lib $(PLIB_DIR)
+	cp -R _build/{{rebar_profile}}/rel/{{package_install_name}}/erts-* $(PLIB_DIR)
+	cp -R _build/{{rebar_profile}}/rel/{{package_install_name}}/releases $(PLIB_DIR)
 	mkdir -p $(PDATA_DIR)
-	cp -R _build/default/rel/{{package_install_name}}/data/* $(PDATA_DIR)
+	cp -R _build/{{rebar_profile}}/rel/{{package_install_name}}/data/* $(PDATA_DIR)
 	mkdir -p ${BUILD_STAGE_DIR}/usr/local/etc/rc.d
 
 
@@ -95,7 +95,7 @@ $(BUILD_STAGE_DIR): buildrel
 #  * copy the vars.config over for build config
 buildrel:
 	OVERLAY_VARS="overlay_vars=../fbsdng/vars.config" $(MAKE) rel
-	chmod 0755 _build/default/rel/{{package_install_name}}/bin/* _build/default/rel/{{package_install_name}}/erts-*/bin/*
+	chmod 0755 _build/{{rebar_profile}}/rel/{{package_install_name}}/bin/* _build/{{rebar_profile}}/rel/{{package_install_name}}/erts-*/bin/*
 
 $(BUILDDIR):
 	mkdir -p $@

--- a/priv/templates/fbsdng/fbsdng.template
+++ b/priv/templates/fbsdng/fbsdng.template
@@ -9,6 +9,7 @@
              {package_install_group, "package_install_group"},
              {bin_or_sbin, "bin"},
              {freebsd_package_category, "db"},
+             {rebar_profile, "default"},
 
              %% Platform-specific installation paths
              {platform_bin_dir,  "/usr/local/{{bin_or_sbin}}"},

--- a/priv/templates/osx/Makefile
+++ b/priv/templates/osx/Makefile
@@ -4,7 +4,7 @@ default: buildrel
 	mkdir -p packages
 	mkdir -p osxbuild
 	cd $(PKG_ID) && \
-		cp -R _build/default/rel/{{package_install_name}} \
+		cp -R _build/{{rebar_profile}}/rel/{{package_install_name}} \
 		   ../osxbuild/{{package_name}}-$(PKG_VERSION)
 	cd osxbuild && \
 		tar -czf ../packages/$(PKGNAME) \

--- a/priv/templates/osx/osx.template
+++ b/priv/templates/osx/osx.template
@@ -3,7 +3,8 @@
 {variables, [
              {package_name, "package_name"},
              {package_install_name, "package_install_name"},
-             {package_install_user, "package_install_user"}
+             {package_install_user, "package_install_user"},
+             {rebar_profile, "default"}
              ]
 }.
 {template, "Makefile", "Makefile"}.

--- a/priv/templates/rpm/rpm.template
+++ b/priv/templates/rpm/rpm.template
@@ -12,7 +12,8 @@
              {vendor_url, "vendor_url"},
              {vendor_contact_name, "vendor_contact"},
              {vendor_contact_email, "vendor_contact_email"},
-             {bin_or_sbin, "bin"}
+             {bin_or_sbin, "bin"},
+             {rebar_profile, "default"}
             ]
 }.
 {template, "Makefile", "Makefile"}.

--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -31,6 +31,8 @@ BuildRoot: %{_tmppath}/%{name}-%{_revision}-%{release}-root
 Summary: {{package_shortdesc}}
 Obsoletes: {{package_name}}
 
+Requires: {{rpm_depends}}
+
 %description
 {{package_desc}}
 

--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -80,7 +80,7 @@ EOF
 OVERLAY_VARS="rpm.vars.config" make rel
 
 %install
-%define relpath       %{_builddir}/%{buildsubdir}/_build/default/rel/{{package_install_name}}
+%define relpath       %{_builddir}/%{buildsubdir}/_build/{{rebar_profile}}/rel/{{package_install_name}}
 %define buildroot_lib %{buildroot}%{_libdir}/{{package_install_name}}
 %define buildroot_etc %{buildroot}%{_sysconfdir}/{{package_install_name}}
 %define buildroot_share %{buildroot}%{_datarootdir}/{{package_install_name}}

--- a/priv/templates/smartos/Makefile
+++ b/priv/templates/smartos/Makefile
@@ -69,7 +69,7 @@ PDATA_ROOT_DIR   = $(shell echo "{{platform_data_dir}}" | cut -d'/' -f 2)
 
 # Recursive assignment of ERTS version
 # We will know this after building the rel
-ERTS_PATH        = $(shell ls $(BUILDDIR)/_build/default/rel/{{package_install_name}} | egrep -o "erts-.*")
+ERTS_PATH        = $(shell ls $(BUILDDIR)/_build/{{rebar_profile}}/rel/{{package_install_name}} | egrep -o "erts-.*")
 
 TARNAME := $(PACKAGE_NAME_CLEAN)-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tar
 PKGNAME := $(PACKAGE_NAME_CLEAN)-$(PKG_VERSION)-$(OSNAME)-$(ARCH).tgz
@@ -210,23 +210,23 @@ templates: $(BUILD_STAGE_DIR)
 $(BUILD_STAGE_DIR): buildrel patch_runner
 	@echo "Copying rel directory to staging directory"
 	mkdir -p $@
-	cp -R $(BUILDDIR)/_build/default/rel/{{package_install_name}} $(BUILD_STAGE_DIR)
+	cp -R $(BUILDDIR)/_build/{{rebar_profile}}/rel/{{package_install_name}} $(BUILD_STAGE_DIR)
 	mkdir -p $(PBIN_DIR)
-	cp -R $(BUILDDIR)/_build/default/rel/{{package_install_name}}/bin/* $(PBIN_DIR)
+	cp -R $(BUILDDIR)/_build/{{rebar_profile}}/rel/{{package_install_name}}/bin/* $(PBIN_DIR)
 	mkdir -p $(PETC_DIR)
-	cp -R $(BUILDDIR)/_build/default rel/{{package_install_name}}/etc/* $(PETC_DIR)
+	cp -R $(BUILDDIR)/_build/{{rebar_profile}} rel/{{package_install_name}}/etc/* $(PETC_DIR)
 	mkdir -p $(PLIB_DIR)
-	cp -R $(BUILDDIR)/_build/default/rel/{{package_install_name}}/lib $(PLIB_DIR)
-	cp -R $(BUILDDIR)/_build/default/rel/{{package_install_name}}/erts-* $(PLIB_DIR)
-	cp -R $(BUILDDIR)/_build/default/rel/{{package_install_name}}/releases $(PLIB_DIR)
+	cp -R $(BUILDDIR)/_build/{{rebar_profile}}/rel/{{package_install_name}}/lib $(PLIB_DIR)
+	cp -R $(BUILDDIR)/_build/{{rebar_profile}}/rel/{{package_install_name}}/erts-* $(PLIB_DIR)
+	cp -R $(BUILDDIR)/_build/{{rebar_profile}}/rel/{{package_install_name}}/releases $(PLIB_DIR)
 	@echo "Copying man pages to staging directory"
 	mkdir -p $(PMAN_DIR)
 	if [ -d $(BUILDDIR)/doc/man/man1 ]; then \
 	    cp -R $(BUILDDIR)/doc/man/man1 $(PMAN_DIR); fi
 	@echo "Copying data and log directories to staging directory"
-	if [ -d $(BUILDDIR)/_build/default/rel/{{package_install_name}}/data ]; then \
+	if [ -d $(BUILDDIR)/_build/{{rebar_profile}}/rel/{{package_install_name}}/data ]; then \
 	   mkdir -p $(PDATA_DIR) && \
-	   cp -R $(BUILDDIR)/_build/default/rel/{{package_install_name}}/data/* $(PDATA_DIR); fi
+	   cp -R $(BUILDDIR)/_build/{{rebar_profile}}/rel/{{package_install_name}}/data/* $(PDATA_DIR); fi
 
 
 # If we can read the PKGSRC_VERSION we should fail
@@ -239,10 +239,10 @@ smartos_check:
 
 # Patch the runner script with SmartOS modifications
 patch_runner: buildrel
-	cp $(PKGERDIR)/runner.patch $(BUILDDIR)/_build/default/rel/{{package_install_name}}/bin/
-	cd $(BUILDDIR)/_build/default/rel/{{package_install_name}}/bin && \
+	cp $(PKGERDIR)/runner.patch $(BUILDDIR)/_build/{{rebar_profile}}/rel/{{package_install_name}}/bin/
+	cd $(BUILDDIR)/_build/{{rebar_profile}}/rel/{{package_install_name}}/bin && \
 	   patch -p0 {{package_install_name}} runner.patch
-	rm $(BUILDDIR)/_build/default/rel/{{package_install_name}}/bin/runner.patch
+	rm $(BUILDDIR)/_build/{{rebar_profile}}/rel/{{package_install_name}}/bin/runner.patch
 
 
 # Build the release we need to package
@@ -250,7 +250,7 @@ patch_runner: buildrel
 #  * copy the vars.config over for build config
 buildrel: $(BUILDDIR) smartos_check
 	OVERLAY_VARS="overlay_vars=../smartos/vars.config" $(MAKE) rel
-	chmod 0755 $(BUILDDIR)/_build/default/rel/{{package_install_name}}/bin/* $(BUILDDIR)/_build/default/rel/{{package_install_name}}/erts-*/bin/*
+	chmod 0755 $(BUILDDIR)/_build/{{rebar_profile}}/rel/{{package_install_name}}/bin/* $(BUILDDIR)/_build/{{rebar_profile}}/rel/{{package_install_name}}/erts-*/bin/*
 
 $(BUILDDIR):
 	mkdir -p $@

--- a/priv/templates/smartos/smartos.template
+++ b/priv/templates/smartos/smartos.template
@@ -8,6 +8,7 @@
              {package_install_user_desc, "package_install_user_desc"},
              {package_install_group, "package_install_group"},
              {bin_or_sbin, "bin"},
+             {rebar_profile, "default"},
 
              %% Platform specific settings
              {platform_bin_dir,  "/opt/local/{{bin_or_sbin}}"},

--- a/priv/templates/solaris/Makefile
+++ b/priv/templates/solaris/Makefile
@@ -27,17 +27,17 @@ buildrel:
 	@# Ye Olde Bourne Shell on Solaris means we have to do it old school
 	echo "Using `which erl` to build"; \
 	OVERLAY_VARS="overlay_vars=../solaris/vars.config" $(MAKE) rel
-	chmod -R go+rX _build/default/rel/{{package_install_name}}
-	chmod 0755 _build/default/rel/{{package_install_name}}/etc
-	chmod -R a+rX _build/default/rel/{{package_install_name}}/etc
-	chmod 0755 _build/default/rel/{{package_install_name}}/lib/env.sh
-	chmod 0755 _build/default/rel/{{package_install_name}}/lib/app_epath.sh
-	chmod 0755 _build/default/rel/{{package_install_name}}/erts-*/bin/nodetool
-	chmod -R go+rX _build/default/rel/{{package_install_name}}/lib/
-	chmod 0755 _build/default/rel/{{package_install_name}}/bin/* \
-		_build/default/rel/{{package_install_name}}/erts-*/bin/*
+	chmod -R go+rX _build/{{rebar_profile}}/rel/{{package_install_name}}
+	chmod 0755 _build/{{rebar_profile}}/rel/{{package_install_name}}/etc
+	chmod -R a+rX _build/{{rebar_profile}}/rel/{{package_install_name}}/etc
+	chmod 0755 _build/{{rebar_profile}}/rel/{{package_install_name}}/lib/env.sh
+	chmod 0755 _build/{{rebar_profile}}/rel/{{package_install_name}}/lib/app_epath.sh
+	chmod 0755 _build/{{rebar_profile}}/rel/{{package_install_name}}/erts-*/bin/nodetool
+	chmod -R go+rX _build/{{rebar_profile}}/rel/{{package_install_name}}/lib/
+	chmod 0755 _build/{{rebar_profile}}/rel/{{package_install_name}}/bin/* \
+		_build/{{rebar_profile}}/rel/{{package_install_name}}/erts-*/bin/*
 	if [ "{{bin_or_sbin}}" != "bin" ]; then \
-	   mv _build/default/rel/{{package_install_name}}/bin _build/default/rel/{{package_install_name}}/{{bin_or_sbin}}; fi
+	   mv _build/{{rebar_profile}}/rel/{{package_install_name}}/bin _build/{{rebar_profile}}/rel/{{package_install_name}}/{{bin_or_sbin}}; fi
 
 depend:
 	cp $(PKGERDIR)/depend .
@@ -56,7 +56,7 @@ prototype:
 	echo "i i.preserve" >> prototype
 	echo "i r.preserve" >> prototype
 	echo '' >> prototype
-	pkgproto _build/default/rel/{{package_install_name}}={{package_install_name}} >> prototype
+	pkgproto _build/{{rebar_profile}}/rel/{{package_install_name}}={{package_install_name}} >> prototype
 	sed -e "s/ $(LOGNAME) .*$$/ root bin/" \
 		-e "s/\([f|d]\) none {{package_install_name}}\/log\(.*\) \(.*\) root bin/\1 none {{package_install_name}}\/log\2 \3 {{package_install_user}} {{package_install_group}}/" \
 		-e "s/\([f|d]\) none {{package_install_name}}\/data\(.*\) \(.*\) root bin/\1 none {{package_install_name}}\/data\2 \3 {{package_install_user}} {{package_install_group}}/" \

--- a/priv/templates/solaris/solaris.template
+++ b/priv/templates/solaris/solaris.template
@@ -8,6 +8,7 @@
              {package_install_user_desc, "package_install_user_desc"},
              {package_install_group, "package_install_group"},
              {bin_or_sbin, "bin"},
+             {rebar_profile, "default"},
 
              %% Platform-specific installation paths
              {platform_bin_dir,  "/opt/{{package_install_name}}/{{bin_or_sbin}}"},


### PR DESCRIPTION
Hi,

This add support to use rebar3 profiles. If rebar_profile is not set, the 'default' profile is used. A usual use case is when we have production profile with specific flags.

Thanks.