### PR TITLE
Remove obsoletes directive

### DIFF
--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -29,7 +29,6 @@ Vendor: {{vendor_name}}
 Packager: {{vendor_contact_name}} <{{vendor_contact_email}}>
 BuildRoot: %{_tmppath}/%{name}-%{_revision}-%{release}-root
 Summary: {{package_shortdesc}}
-Obsoletes: {{package_name}}
 
 %description
 {{package_desc}}


### PR DESCRIPTION
It seems the `Obsoletes` directive makes it impossible to upgrade the VerneMQ package and when attempted to one get's an error like this:

```
$ sudo yum install vernemq-1.1.0-1.el7.centos.x86_64.rpm 
Examining vernemq-1.1.0-1.el7.centos.x86_64.rpm: vernemq-1.1.0-1.el7.centos.x86_64
Cannot install package vernemq-1.1.0-1.el7.centos.x86_64. It is obsoleted by installed package vernemq-1.0.1-1.el7.centos.x86_64
Error: Nothing to do
```

Without the directive in the specs this seems to work correctly. I don't have a lot of experience with RPM packages, so even though this seems to work, I find it odd that basho would have something like this in the standard template and that makes me a bit uncertain if this can really be a bug they've been having as well.